### PR TITLE
Fix negative mapping quality.

### DIFF
--- a/src/AlignmentBuffer.cpp
+++ b/src/AlignmentBuffer.cpp
@@ -44,6 +44,7 @@ void AlignmentBuffer::addRead(MappedRead * read, int scoreID) {
 		SaveRead(read, read->hasCandidates());
 	} else {
 		if (!read->hasCandidates() || read->mappingQlty < min_mq) {
+			/* setting a min_mq > 0 can trigger a premature free of the read in line 211 */
 			//If read has no CMRs or mapping quality is lower than min mapping quality, output unmapped read
 			//read->clearScores(-1);
 			SaveRead(read, false);

--- a/src/ScoreBuffer.cpp
+++ b/src/ScoreBuffer.cpp
@@ -32,6 +32,9 @@ bool sortLocationScore(LocationScore a, LocationScore b) {
 }
 
 int ScoreBuffer::computeMQ(float bestScore, float secondBestScore) {
+	if(bestScore <= 0) {
+		return 0;
+	}
 	int mq = ceil(MAX_MQ * (bestScore - secondBestScore) / bestScore);
 	return mq;
 }


### PR DESCRIPTION
Hi Guys,

@breichholf and me ran into a bug with NGM, that manifests itself as a segfault, with some input files. We debugged this and found the following behaviour:

For certain reads the ScoreBuffer::computeMQ() function returns negative values. This happens when the best score is zero, which triggers a division by zero and sets the mapping quality to a negative value. This has been fixed in this PR.
What has not been fixed is a related bug: if min_mq is set to a non-zero value the read is freed by calling AlignmentBuffer::SaveRead(), which in turn calls ReadProvider::DisposeRead(). If the read is still used this will lead to a segfault (this is what we actually saw).

Afaik @breichholf contacted you already, but I guess a PR could speed up things. ;)

Best regards, 
Georg