### PR TITLE
Added T>C conversion and 5p-trimming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,9 @@ set( NGM_VERSION_MAJOR 0 )
 set( NGM_VERSION_MINOR 4 )
 IF(CMAKE_BUILD_TYPE STREQUAL "Debug")
     message(STATUS "Building in debug mode!")
-    set( NGM_VERSION_BUILD 13-debug )
+    set( NGM_VERSION_BUILD 13-slambr-debug )
 else()
-  set( NGM_VERSION_BUILD 13 )
+  set( NGM_VERSION_BUILD 13-slambr )
 ENDIF()
 
 
@@ -17,7 +17,7 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin/ngm-${NGM_VERSION_MAJOR}.${
 file(MAKE_DIRECTORY ${EXECUTABLE_OUTPUT_PATH})
 
 #add_definitions(-D INSTANCE_COUNTING)
-#VERBOSE OUTPUT 
+#VERBOSE OUTPUT
 #add_definitions(-D VERBOSE)
 #DEBUG OUTPUT FOR CS (FILE: cs-results.txt)
 #add_definitions(-D _DEBUGCS)
@@ -49,7 +49,7 @@ IF(NOT APPLE)
 	add_subdirectory(opencl-sdk)
 endif()
 
-IF(APPLE) 
+IF(APPLE)
   set(GDB "ggdb")
   set(OPENCL_LIBRARIES "-framework OpenCL")
 ELSE()
@@ -79,9 +79,9 @@ file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/ngm" "#!/bin/bash
 
 pushd . > /dev/null
 SCRIPT_PATH=\"\${BASH_SOURCE[0]}\";
-  while([ -h \"\${SCRIPT_PATH}\" ]) do 
+  while([ -h \"\${SCRIPT_PATH}\" ]) do
     cd \"`dirname \"\${SCRIPT_PATH}\"`\"
-    SCRIPT_PATH=\"$(readlink \"`basename \"\${SCRIPT_PATH}\"`\")\"; 
+    SCRIPT_PATH=\"$(readlink \"`basename \"\${SCRIPT_PATH}\"`\")\";
   done
 cd \"`dirname \"\${SCRIPT_PATH}\"`\" > /dev/null
 SCRIPT_PATH=\"`pwd`\";
@@ -97,9 +97,9 @@ file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/ngm-log" "#!/bin/bash
 
 pushd . > /dev/null
 SCRIPT_PATH=\"\${BASH_SOURCE[0]}\";
-  while([ -h \"\${SCRIPT_PATH}\" ]) do 
+  while([ -h \"\${SCRIPT_PATH}\" ]) do
     cd \"`dirname \"\${SCRIPT_PATH}\"`\"
-    SCRIPT_PATH=\"$(readlink \"`basename \"\${SCRIPT_PATH}\"`\")\"; 
+    SCRIPT_PATH=\"$(readlink \"`basename \"\${SCRIPT_PATH}\"`\")\";
   done
 cd \"`dirname \"\${SCRIPT_PATH}\"`\" > /dev/null
 SCRIPT_PATH=\"`pwd`\";
@@ -115,9 +115,9 @@ file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/ngm-debug" "#!/bin/bash
 
 pushd . > /dev/null
 SCRIPT_PATH=\"\${BASH_SOURCE[0]}\";
-  while([ -h \"\${SCRIPT_PATH}\" ]) do 
+  while([ -h \"\${SCRIPT_PATH}\" ]) do
     cd \"`dirname \"\${SCRIPT_PATH}\"`\"
-    SCRIPT_PATH=\"$(readlink \"`basename \"\${SCRIPT_PATH}\"`\")\"; 
+    SCRIPT_PATH=\"$(readlink \"`basename \"\${SCRIPT_PATH}\"`\")\";
   done
 cd \"`dirname \"\${SCRIPT_PATH}\"`\" > /dev/null
 SCRIPT_PATH=\"`pwd`\";
@@ -132,5 +132,3 @@ OPENCL_VENDOR_PATH=\"$SCRIPT_PATH/opencl/vendor\" LD_LIBRARY_PATH=\"$SCRIPT_PATH
 file(COPY "${CMAKE_CURRENT_BINARY_DIR}/ngm-debug" DESTINATION "${EXECUTABLE_OUTPUT_PATH}" FILE_PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ NO_SOURCE_PERMISSIONS)
 file(COPY "${CMAKE_CURRENT_BINARY_DIR}/ngm" DESTINATION "${EXECUTABLE_OUTPUT_PATH}" FILE_PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ NO_SOURCE_PERMISSIONS)
 file(COPY "${CMAKE_CURRENT_BINARY_DIR}/ngm-log" DESTINATION "${EXECUTABLE_OUTPUT_PATH}" FILE_PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ NO_SOURCE_PERMISSIONS)
-
-

--- a/include/IAlignment.h
+++ b/include/IAlignment.h
@@ -42,12 +42,14 @@ public:
 
 	virtual int BatchScore(int const mode, int const batchSize,
 			char const * const * const refSeqList,
-			char const * const * const qrySeqList, float * const results,
+			char const * const * const qrySeqList,
+			char const * const * const qalSeqList, float * const results,
 			void * extData) = 0;
 
 	virtual int BatchAlign(int const mode, int const batchSize,
 			char const * const * const refSeqList,
-			char const * const * const qrySeqList, Align * const results,
+			char const * const * const qrySeqList,
+			char const * const * const qalSeqList, Align * const results,
 			void * extData) = 0;
 };
 

--- a/include/IConfig.h
+++ b/include/IConfig.h
@@ -46,6 +46,7 @@ static char const * const BIN_SIZE = "bin_size";
 static char const * const SLAM_SEQ = "slam_seq";
 
 static char const * const MAX_KFREQ = "max_kfreq";
+static char const * const TRIM5 = "trim5";
 
 #ifdef DEBUGLOG
 static char const * const LOG = "log";

--- a/include/IConfig.h
+++ b/include/IConfig.h
@@ -43,6 +43,7 @@ static char const * const MAX_READ_LENGTH = "max_read_length";
 static char const * const RLENGTH_CHECK = "force_rlength_check";
 
 static char const * const BIN_SIZE = "bin_size";
+static char const * const SLAM_SEQ = "slam_seq";
 
 static char const * const MAX_KFREQ = "max_kfreq";
 

--- a/lib/mason/opencl/SWOcl.cpp
+++ b/lib/mason/opencl/SWOcl.cpp
@@ -118,7 +118,7 @@ int SWOcl::BatchScore(int const mode, int const batchSize_, char const * const *
 
 	cl_mem bsdirection_gpu = 0;
 	static bool const bsMapping = Config.GetInt("bs_mapping") == 1;
-	if (bsMapping) {
+	if (bsMapping || (slamSeq & 0x2)) {
 		if (host->isGPU()) {
 			bsdirection_gpu = host->allocate(CL_MEM_READ_ONLY, batch_size_scoring * sizeof(cl_char));
 		} else {
@@ -563,4 +563,3 @@ unsigned int SWOcl::computeScoringBatchSize() {
 		return 2048;
 	}
 }
-

--- a/lib/mason/opencl/SWOcl.cpp
+++ b/lib/mason/opencl/SWOcl.cpp
@@ -205,17 +205,21 @@ SWOcl::SWOcl(char const * const oclSwScoreSourceCode, char const * const additio
 
 	stringstream buildCmd;
 	static bool const bsMapping = Config.GetInt("bs_mapping") == 1;
-	buildCmd << "-D MATRIX_LENGTH=" << (matrix_length * threads_per_block) << " -D interleave_number=" << "256" << " -D threads_per_block="
-			<< threads_per_block << " -D match=" << Config.GetFloat(MATCH_BONUS) << " -D mismatch=" << Config.GetFloat(MISMATCH_PENALTY) * -1.0f
-			<< " -D gap_read=" << Config.GetFloat(GAP_READ_PENALTY) * -1.0f << " -D gap_ref=" << Config.GetFloat(GAP_REF_PENALTY) * -1.0f << " -D matchBS="
-			<< Config.GetFloat(MATCH_BONUS_TT) << " -D mismatchBS=" << Config.GetFloat(MATCH_BONUS_TC) << " -D read_length="
-			<< Config.GetInt("qry_max_len") << " -D ref_length=" << config_ref_size << " -D corridor_length="
-			<< (Config.GetInt("corridor") + 1) << " -D alignment_length=" << alignment_length;
+	buildCmd << "-D MATRIX_LENGTH=" << (matrix_length * threads_per_block)
+			<< " -D interleave_number=" << "256" << " -D threads_per_block="
+			<< threads_per_block << " -D match=" << Config.GetFloat(MATCH_BONUS)
+			<< " -D mismatch=" << Config.GetFloat(MISMATCH_PENALTY) * -1.0f
+			<< " -D gap_read=" << Config.GetFloat(GAP_READ_PENALTY) * -1.0f
+			<< " -D gap_ref=" << Config.GetFloat(GAP_REF_PENALTY) * -1.0f
+			<< " -D read_length=" << Config.GetInt("qry_max_len")
+			<< " -D ref_length=" << config_ref_size << " -D corridor_length="
+			<< (Config.GetInt("corridor") + 1) << " -D alignment_length="
+			<< alignment_length;
 	buildCmd << additional_defines;
 	if (host->isGPU()) {
-		buildCmd << "-D __GPU__";
+		buildCmd << " -D __GPU__";
 	} else {
-		buildCmd << "-D __CPU__";
+		buildCmd << " -D __CPU__";
 	}
 	/* old version
 	if (bsMapping) {

--- a/lib/mason/opencl/SWOcl.cpp
+++ b/lib/mason/opencl/SWOcl.cpp
@@ -30,7 +30,11 @@ long overall = 0;
 
 bool usedPinnedMemory = true;
 
-int SWOcl::BatchScore(int const mode, int const batchSize_, char const * const * const refSeqList_, char const * const * const qrySeqList_, float * const results_, void * extData) {
+int SWOcl::BatchScore(int const mode, int const batchSize_,
+		char const * const * const refSeqList_,
+		char const * const * const qrySeqList_,
+		char const * const * const qalSeqList, float * const results_,
+		void * extData) {
 
 	if (batchSize_ <= 0) {
 		Log.Warning("Score for batchSize <= 0");

--- a/lib/mason/opencl/SWOcl.h
+++ b/lib/mason/opencl/SWOcl.h
@@ -57,7 +57,12 @@ private:
 protected:
 
 	/*Number of threads executed by each multi processor*/
+	#ifdef __APPLE__
+	static unsigned int const threads_per_block = 1;
+	#else
 	static unsigned int const threads_per_block = 256;
+	#endif
+	
 	unsigned int block_multiplier;
 	unsigned int step_count;
 

--- a/lib/mason/opencl/SWOcl.h
+++ b/lib/mason/opencl/SWOcl.h
@@ -41,9 +41,9 @@ public:
 	virtual int GetScoreBatchSize() const;
 	virtual int GetAlignBatchSize() const = 0;
 	virtual int BatchScore(const int mode, const int batchSize, const char * const * const refSeqList,
-			const char * const * const qrySeqList, float * const results, void * extData);
+			const char * const * const qrySeqList, char const * const * const qalSeqList, float * const results, void * extData);
 	virtual int BatchAlign(const int mode, const int batchSize, const char * const * const refSeqList,
-			const char * const * const qrySeqList, Align * const results, void * extData) = 0;
+			const char * const * const qrySeqList, char const * const * const qalSeqList, Align * const results, void * extData) = 0;
 
 	OclHost * getHost() {
 		return host;

--- a/lib/mason/opencl/SWOcl.h
+++ b/lib/mason/opencl/SWOcl.h
@@ -65,6 +65,9 @@ protected:
 	int matrix_length;
 	int config_ref_size;
 
+	bool const bsMapping;
+	int const slamSeq;
+
 	OclHost * host;
 	//static int programUserCount;
 //	static cl_program clProgram;

--- a/lib/mason/opencl/SWOclCigar.cpp
+++ b/lib/mason/opencl/SWOclCigar.cpp
@@ -367,6 +367,21 @@ bool debugCigar(int op, int length) {
 	return true;
 }
 
+int const baseNumber = 5;
+int trans[256] = { 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+		4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+		4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 1,
+		4, 4, 4, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 4, 4, 4, 4, 4, 4, 4,
+		4, 4, 4, 4, 4, 0, 4, 1, 4, 4, 4, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+		3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+		4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+		4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+		4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+		4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+		4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 };
+
+char back[baseNumber] = { 'A', 'C', 'G', 'T', 'N' };
+
 bool SWOclCigar::computeCigarMD(Align & result, int const gpuCigarOffset, short const * const gpuCigar, char const * const refSeq, char const * const qrySeq, char const bsFrom, char const bsTo) {
 
 	static bool const bsMapping = Config.GetInt("bs_mapping") == 1;

--- a/lib/mason/opencl/SWOclCigar.cpp
+++ b/lib/mason/opencl/SWOclCigar.cpp
@@ -47,7 +47,13 @@ SWOclCigar::~SWOclCigar() {
 	clReleaseKernel(swAlignScoreKernelGlobal);
 }
 
-void SWOclCigar::runSwBatchKernel(cl_kernel swScoreAlign, const int batchSize, const char * const * const qrySeqList, const char * const * const refSeqList, char * bsDirection, cl_mem & results_gpu, cl_mem & alignments, short * const result, short * calignments, cl_mem & matrix_gpu, cl_mem & bsdirection_gpu) {
+void SWOclCigar::runSwBatchKernel(cl_kernel swScoreAlign, const int batchSize,
+																	const char * const * const qrySeqList,
+																	const char * const * const refSeqList,
+																	char * bsDirection, cl_mem & results_gpu,
+																	cl_mem & alignments, short * const result,
+																	short * calignments, cl_mem & matrix_gpu,
+																	cl_mem & bsdirection_gpu) {
 	const size_t cnDim = batch_size_align / alignments_per_thread;
 	const size_t cBlockSize = threads_per_block;
 
@@ -86,7 +92,7 @@ void SWOclCigar::runSwBatchKernel(cl_kernel swScoreAlign, const int batchSize, c
 }
 
 int SWOclCigar::BatchAlign(int const mode, int const batchSize_,
-	  char const * const * const refSeqList_,
+		char const * const * const refSeqList_,
 		char const * const * const qrySeqList_,
 		char const * const * const qalSeqList, Align * const results, void * extData) {
 	if (batchSize_ <= 0) {

--- a/lib/mason/opencl/SWOclCigar.cpp
+++ b/lib/mason/opencl/SWOclCigar.cpp
@@ -85,7 +85,10 @@ void SWOclCigar::runSwBatchKernel(cl_kernel swScoreAlign, const int batchSize, c
 	host->waitForDevice();
 }
 
-int SWOclCigar::BatchAlign(int const mode, int const batchSize_, char const * const * const refSeqList_, char const * const * const qrySeqList_, Align * const results, void * extData) {
+int SWOclCigar::BatchAlign(int const mode, int const batchSize_,
+	  char const * const * const refSeqList_,
+		char const * const * const qrySeqList_,
+		char const * const * const qalSeqList, Align * const results, void * extData) {
 	if (batchSize_ <= 0) {
 		Log.Warning("Align for batchSize <= 0");
 		return 0;
@@ -277,7 +280,7 @@ int SWOclCigar::BatchAlign(int const mode, int const batchSize_, char const * co
 		}
 
 		if (!computeCigarMD(results[i], gpu_return_values[offset + alignments_per_thread * 3 + k], gpuCigar,
-				refSeqList[i] + gpu_return_values[offset + k], qrySeqList[i], bsFrom, bsTo)) {
+				refSeqList[i] + gpu_return_values[offset + k], qrySeqList[i], qalSeqList[i], bsFrom, bsTo)) {
 			results[i].Score = -1.0f;
 		}
 		results[i].PositionOffset = gpu_return_values[offset + k];
@@ -382,7 +385,10 @@ int trans[256] = { 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
 
 char back[baseNumber] = { 'A', 'C', 'G', 'T', 'N' };
 
-bool SWOclCigar::computeCigarMD(Align & result, int const gpuCigarOffset, short const * const gpuCigar, char const * const refSeq, char const * const qrySeq, char const bsFrom, char const bsTo) {
+bool SWOclCigar::computeCigarMD(Align & result, int const gpuCigarOffset,
+	  short const * const gpuCigar, char const * const refSeq,
+		char const * const qrySeq, char const * const qalSeq, char const bsFrom,
+		char const bsTo) {
 
 	static bool const bsMapping = Config.GetInt("bs_mapping") == 1;
 	int cigar_offset = 0;

--- a/lib/mason/opencl/SWOclCigar.h
+++ b/lib/mason/opencl/SWOclCigar.h
@@ -18,7 +18,7 @@ public:
 	SWOclCigar(OclHost * host);
 	virtual ~SWOclCigar();
 	virtual int BatchAlign(int const mode, int const batchSize, char const * const * const refSeqList,
-			char const * const * const qrySeqList, Align * const results, void * extData);
+			char const * const * const qrySeqList, char const * const * const qalSeqList, Align * const results, void * extData);
 
 	virtual int GetAlignBatchSize() const;
 
@@ -33,7 +33,7 @@ private:
 	void runSwBatchKernel(cl_kernel swScoreAlign, const int batchSize, const char * const * const qrySeqList,
 			const char * const * const refSeqList, char * bsDirection, cl_mem & results_gpu, cl_mem & alignments, short * const result,
 			short * calignments, cl_mem & matrix_gpu, cl_mem & bsdirection_gpu);
-	bool computeCigarMD(Align & result, int const gpuCigarOffset, short const * const gpuCigar, char const * const refSeq, char const * const qrySeq, char const bsFrom, char const bsTo);
+	bool computeCigarMD(Align & result, int const gpuCigarOffset, short const * const gpuCigar, char const * const refSeq, char const * const qrySeq, char const * const qalSeq, char const bsFrom, char const bsTo);
 
 	int computeAlignmentBatchSize();
 

--- a/lib/mason/opencl/opencl/oclDefines.cl
+++ b/lib/mason/opencl/opencl/oclDefines.cl
@@ -108,3 +108,40 @@ __cl_constant float scoresAG[7][7] = { {matchBS,  mismatch, mismatchBS, mismatch
  	 	 	 	 	 	 	 	 	   {mismatch, mismatch, mismatch,   mismatch, mismatch, mismatch, 0},
  	 	 	 	 	 	 	 	 	   {0,        0,        0,          0,        0,        0       , 0}       ,
  	 	 	 	 	 	 	 	 	   {0,        0,        0,          0,        0,        0       , 0} };
+//Ref ->
+  //A			C		  G         T         X         N         \0
+__cl_constant float scoresBsFWD[7][7] ={ {match,    mismatch,   mismatch, mismatch, mismatch, mismatch, 0},
+/*Read*/							   {mismatch, match,      mismatch, mismatch, mismatch, mismatch, 0},
+/*|*/								   {mismatch, mismatch,   match,    mismatch, mismatch, mismatch, 0},
+/*v*/								   {mismatch, mismatchALT, mismatch, matchALT,  mismatch, mismatch, 0},
+	 	   	   	   	   	   	   	   	   {mismatch, mismatch,   mismatch, mismatch, mismatch, mismatch, 0},
+									   {0,        0,          0,        0,        mismatch, mismatch, mismatch},
+									   {0,        0,          0,        0,        0,        0       , 0} };
+
+
+__cl_constant float scoresBsREV[7][7] = { {matchALT,  mismatch, mismatchALT, mismatch, mismatch, mismatch, 0},
+/*Read*/							   {mismatch, match,    mismatch,   mismatch, mismatch, mismatch, 0},
+/*|*/								   {mismatch, mismatch, match,      mismatch, mismatch, mismatch, 0},
+/*v*/								   {mismatch, mismatch, mismatch,   match,    mismatch, mismatch, 0},
+	 	   	   	   	   	   	   	   	   {mismatch, mismatch, mismatch,   mismatch, mismatch, mismatch, 0},
+									   {0,        0,        0,          0,        0,        0       , 0}       ,
+									   {0,        0,        0,          0,        0,        0       , 0} };
+
+//Ref ->
+//A			C		  G         T         X         N         \0
+__cl_constant float scoresSlamSeqFWD[7][7] ={ {match,    mismatch,   mismatch, mismatch, mismatch, mismatch, 0},
+/*Read*/							   {mismatch, match,      mismatch, mismatchALT, mismatch, mismatch, 0},
+/*|*/								   {mismatch, mismatch,   match,    mismatch, mismatch, mismatch, 0},
+/*v*/								   {mismatch, mismatch, mismatch, matchALT,  mismatch, mismatch, 0},
+	 	   	   	   	   	   	   	   	   {mismatch, mismatch,   mismatch, mismatch, mismatch, mismatch, 0},
+									   {0,        0,          0,        0,        mismatch, mismatch, mismatch},
+									   {0,        0,          0,        0,        0,        0       , 0} };
+
+
+__cl_constant float scoresSlamSeqREV[7][7] = { {matchALT,  mismatch, mismatch, mismatch, mismatch, mismatch, 0},
+/*Read*/							   {mismatch, match,    mismatch,   mismatch, mismatch, mismatch, 0},
+/*|*/								   {mismatchALT, mismatch, match,      mismatch, mismatch, mismatch, 0},
+/*v*/								   {mismatch, mismatch, mismatch,   match,    mismatch, mismatch, 0},
+	 	   	   	   	   	   	   	   	   {mismatch, mismatch, mismatch,   mismatch, mismatch, mismatch, 0},
+									   {0,        0,        0,          0,        0,        0       , 0}       ,
+									   {0,        0,        0,          0,        0,        0       , 0} };

--- a/lib/mason/opencl/opencl/oclDefines.cl
+++ b/lib/mason/opencl/opencl/oclDefines.cl
@@ -80,8 +80,8 @@ __cl_constant int trans[256] =
 				4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 };
 
 
-									//Ref ->
-									//A			C		  G         T         X         N         \0
+//Ref ->
+//A			C		  G         T         X         N         \0
 __cl_constant float scores[7][7] = { {match,    mismatch, mismatch, mismatch, mismatch, mismatch, 0},
 /*Read*/							 {mismatch, match,    mismatch, mismatch, mismatch, mismatch, 0},
 /*|*/								 {mismatch, mismatch, match,    mismatch, mismatch, mismatch, 0},
@@ -90,8 +90,8 @@ __cl_constant float scores[7][7] = { {match,    mismatch, mismatch, mismatch, mi
 									 {0,        0,        0,        0,        mismatch, mismatch, mismatch},
 									 {0,        0,        0,        0,        0,        0       , 0} };
 
-									   //Ref ->
-									   //A			C		  G         T         X         N         \0
+//Ref ->
+//A			C		  G         T         X         N         \0
 __cl_constant float scoresTC[7][7] = { {match,    mismatch,   mismatch, mismatch, mismatch, mismatch, 0},
 /*Read*/							   {mismatch, match,      mismatch, mismatch, mismatch, mismatch, 0},
 /*|*/								   {mismatch, mismatch,   match,    mismatch, mismatch, mismatch, 0},
@@ -108,8 +108,8 @@ __cl_constant float scoresAG[7][7] = { {matchBS,  mismatch, mismatchBS, mismatch
  	 	 	 	 	 	 	 	 	   {mismatch, mismatch, mismatch,   mismatch, mismatch, mismatch, 0},
  	 	 	 	 	 	 	 	 	   {0,        0,        0,          0,        0,        0       , 0}       ,
  	 	 	 	 	 	 	 	 	   {0,        0,        0,          0,        0,        0       , 0} };
-//Ref ->
-  //A			C		  G         T         X         N         \0
+	//Ref ->
+	//A			C		  G         T         X         N         \0
 __cl_constant float scoresBsFWD[7][7] ={ {match,    mismatch,   mismatch, mismatch, mismatch, mismatch, 0},
 /*Read*/							   {mismatch, match,      mismatch, mismatch, mismatch, mismatch, 0},
 /*|*/								   {mismatch, mismatch,   match,    mismatch, mismatch, mismatch, 0},

--- a/lib/mason/opencl/opencl/oclDefines.cl
+++ b/lib/mason/opencl/opencl/oclDefines.cl
@@ -89,25 +89,6 @@ __cl_constant float scores[7][7] = { {match,    mismatch, mismatch, mismatch, mi
 									 {mismatch, mismatch, mismatch, mismatch, mismatch, mismatch, 0},
 									 {0,        0,        0,        0,        mismatch, mismatch, mismatch},
 									 {0,        0,        0,        0,        0,        0       , 0} };
-
-//Ref ->
-//A			C		  G         T         X         N         \0
-__cl_constant float scoresTC[7][7] = { {match,    mismatch,   mismatch, mismatch, mismatch, mismatch, 0},
-/*Read*/							   {mismatch, match,      mismatch, mismatch, mismatch, mismatch, 0},
-/*|*/								   {mismatch, mismatch,   match,    mismatch, mismatch, mismatch, 0},
-/*v*/								   {mismatch, mismatchBS, mismatch, matchBS,  mismatch, mismatch, 0},
- 	 	 	 	 	 	 	 	 	   {mismatch, mismatch,   mismatch, mismatch, mismatch, mismatch, 0},
- 	 	 	 	 	 	 	 	 	   {0,        0,          0,        0,        mismatch, mismatch, mismatch},
- 	 	 	 	 	 	 	 	 	   {0,        0,          0,        0,        0,        0       , 0} };
-
-
-__cl_constant float scoresAG[7][7] = { {matchBS,  mismatch, mismatchBS, mismatch, mismatch, mismatch, 0},
-/*Read*/							   {mismatch, match,    mismatch,   mismatch, mismatch, mismatch, 0},
-/*|*/								   {mismatch, mismatch, match,      mismatch, mismatch, mismatch, 0},
-/*v*/								   {mismatch, mismatch, mismatch,   match,    mismatch, mismatch, 0},
- 	 	 	 	 	 	 	 	 	   {mismatch, mismatch, mismatch,   mismatch, mismatch, mismatch, 0},
- 	 	 	 	 	 	 	 	 	   {0,        0,        0,          0,        0,        0       , 0}       ,
- 	 	 	 	 	 	 	 	 	   {0,        0,        0,          0,        0,        0       , 0} };
 	//Ref ->
 	//A			C		  G         T         X         N         \0
 __cl_constant float scoresBsFWD[7][7] ={ {match,    mismatch,   mismatch, mismatch, mismatch, mismatch, 0},

--- a/lib/mason/opencl/opencl/oclEndFreeScore.cl
+++ b/lib/mason/opencl/opencl/oclEndFreeScore.cl
@@ -1,6 +1,11 @@
 #ifdef __CPU__
 
+#ifndef __ALT_SCORING__
 __kernel void oclSW_Global(__global char const * scaff, __global char const * read, __global float * results) {
+#else
+__kernel void oclSW_Global(__global char const * scaff, __global char const * read, __global float * results, __global char const * direction) {
+	int4 direction4 = convert_int4(vload4(global_index, direction));
+#endif
 
 	scaff = scaff + (global_index * ref_length * 4);
 	read = read + (global_index * read_length * 4);
@@ -28,7 +33,11 @@ __kernel void oclSW_Global(__global char const * scaff, __global char const * re
 				//Max can be set to left_cell because we are computing the score row-wise, so the actual max is the left_cell for the next cell
 				left_cell = max(matrix_lines[(ref_index + 1)] + gap_read, left_cell + gap_ref);
 
+				#ifndef __ALT_SCORING__
 				float4 scores4 = (float4)(scores[read_char_cache.s0][trans[scaff[ref_index]]], scores[read_char_cache.s1][trans[scaff[ref_index + 1 * ref_length]]], scores[read_char_cache.s2][trans[scaff[ref_index + 2 * ref_length]]], scores[read_char_cache.s3][trans[scaff[ref_index + 3 * ref_length]]]);
+				#else
+				float4 scores4 = select((float4)(scoresREV[read_char_cache.s0][trans[scaff[ref_index]]], scoresREV[read_char_cache.s1][trans[scaff[ref_index + 1 * ref_length]]], scoresREV[read_char_cache.s2][trans[scaff[ref_index + 2 * ref_length]]], scoresREV[read_char_cache.s3][trans[scaff[ref_index + 3 * ref_length]]]), (float4)(scoresFWD[read_char_cache.s0][trans[scaff[ref_index]]], scoresFWD[read_char_cache.s1][trans[scaff[ref_index + 1 * ref_length]]], scoresFWD[read_char_cache.s2][trans[scaff[ref_index + 2 * ref_length]]], scoresFWD[read_char_cache.s3][trans[scaff[ref_index + 3 * ref_length]]]), direction4 == 0);
+				#endif
 				left_cell = max(matrix_lines[ref_index] + scores4, left_cell);
 
 				matrix_lines[ref_index] = left_cell;
@@ -43,7 +52,13 @@ __kernel void oclSW_Global(__global char const * scaff, __global char const * re
 	vstore4(curr_max, global_index, results);
 }
 
+#ifndef __ALT_SCORING
 __kernel void oclSW_ScoreGlobal(__global char const * scaff, __global char const * read, __global short * result, __global char * matrix) {
+#else
+__kernel void oclSW_ScoreGlobal(__global char const * scaff, __global char const * read, __global short * result, __global char * matrix, __global char const * direction) {
+
+	int4 direction4 =  convert_int4(vload4(global_index, direction));
+#endif
 
 	matrix = matrix + (global_index * ((corridor_length + 1) * (read_length + 1)) * 4);
 	read = read + (global_index * read_length * 4);
@@ -53,7 +68,7 @@ __kernel void oclSW_ScoreGlobal(__global char const * scaff, __global char const
 
 	float4 best_ref_index4 = null4;
 	float4 read_index = null4;
-	
+
 	if (read[0] != line_end) {
 		float4 l_matrix_lines[MATRIX_LENGTH];
 		float4 * local_matrix_line = l_matrix_lines + local_index * corridor_length;
@@ -63,7 +78,7 @@ __kernel void oclSW_ScoreGlobal(__global char const * scaff, __global char const
 			vstore4(CIGAR_STOP, i, matrix);
 		}
 		vstore4(CIGAR_STOP, corridor_length, matrix);
-		local_matrix_line[corridor_length - 1] = short_min;		
+		local_matrix_line[corridor_length - 1] = short_min;
 
 		for (short read_pos = 0; read_pos < read_length; ++read_pos) {
 
@@ -81,9 +96,15 @@ __kernel void oclSW_ScoreGlobal(__global char const * scaff, __global char const
 				//init values
 				left_cell += gap_ref4;
 
+				#ifndef __ALT_SCORING__
 				float4 score = (float4)(scores[read_char_cache.s0][trans[scaff[ref_index]]], scores[read_char_cache.s1][trans[scaff[ref_index + 1 * ref_length]]], scores[read_char_cache.s2][trans[scaff[ref_index + 2 * ref_length]]], scores[read_char_cache.s3][trans[scaff[ref_index + 3 * ref_length]]]);
 				float4 diag_cell = local_matrix_line[ref_index] + score;
 				float4 pointerX = select(CIGAR_X4, CIGAR_EQ4, (score == match));
+				#else
+				float4 score = select((float4)(scoresREV[read_char_cache.s0][trans[scaff[ref_index]]], scoresREV[read_char_cache.s1][trans[scaff[ref_index + 1 * ref_length]]], scoresREV[read_char_cache.s2][trans[scaff[ref_index + 2 * ref_length]]], scoresREV[read_char_cache.s3][trans[scaff[ref_index + 3 * ref_length]]]), (float4)(scoresFWD[read_char_cache.s0][trans[scaff[ref_index]]], scoresFWD[read_char_cache.s1][trans[scaff[ref_index + 1 * ref_length]]], scoresFWD[read_char_cache.s2][trans[scaff[ref_index + 2 * ref_length]]], scoresFWD[read_char_cache.s3][trans[scaff[ref_index + 3 * ref_length]]]), direction4 == 0);
+				float4 diag_cell = local_matrix_line[ref_index] + score;
+				float4 pointerX = select(CIGAR_X4, CIGAR_EQ4, (read_char_cache == (int4)(trans[scaff[ref_index]], trans[scaff[ref_index + 1 * ref_length]], trans[scaff[ref_index + 2 * ref_length]], trans[scaff[ref_index + 3 * ref_length]])));
+				#endif
 
 				float4 up_cell = local_matrix_line[(ref_index + 1)] + gap_read4;
 
@@ -147,7 +168,15 @@ __kernel void oclSW_Global(__global char const * scaff, __global char const * re
 		for (int ref_index = 0; ref_index < (corridor_length - 1); ++ref_index) {
 
 			short diag_cell = matrix_lines[ref_index * threads_per_block];
+			#ifndef __ALT_SCORING__
 			diag_cell += scores[trans[read_char_cache]][trans[scaff[ref_index * interleave_number]]];
+			#else
+			if(direction[global_index] == 0) {
+				diag_cell += scoresFWD[trans[read_char_cache]][trans[scaff[ref_index * interleave_number]]];
+			} else {
+				diag_cell += scoresREV[trans[read_char_cache]][trans[scaff[ref_index * interleave_number]]];
+			}
+			#endif
 
 			//Max can be set to left_cell because we are computing the score row-wise, so the actual max is the left_cell for the next cell
 			left_cell = max((matrix_lines[ref_index * threads_per_block + threads_per_block] + gap_read), left_cell + gap_ref);
@@ -164,7 +193,11 @@ __kernel void oclSW_Global(__global char const * scaff, __global char const * re
 	results[global_index] = curr_max;
 }
 
+#ifndef __ALT_SCORING__
 __kernel void oclSW_ScoreGlobal(__global char const * scaff, __global char const * read, __global short * result, __global char * matrix) {
+#else
+__kernel void oclSW_ScoreGlobal(__global char const * scaff, __global char const * read, __global short * result, __global char * matrix, __global char const * direction) {
+#endif
 
 	matrix = matrix + ((global_index / threads_per_block) * threads_per_block * ((corridor_length + 1) * (read_length + 1))) + global_index % threads_per_block;
 	read = read + (global_index * read_length);
@@ -187,7 +220,7 @@ __kernel void oclSW_ScoreGlobal(__global char const * scaff, __global char const
 
 	short read_index = 0;
 
-//			bool test = read[0] != '\0';	
+//			bool test = read[0] != '\0';
 //			if (test) {
 //				//printf("GPU Ref : %s\n", scaff);
 //				//printf("GPU Read: %s\n", read);
@@ -219,8 +252,19 @@ __kernel void oclSW_ScoreGlobal(__global char const * scaff, __global char const
 			//			printf("%c == %c\n", read_char_cache, scaff[ref_index * interleave_number]);
 			int pointer = CIGAR_X;
 
+			#ifndef __ALT_SCORING__
 			diag_cell += scores[trans[read_char_cache]][trans[scaff[ref_index * interleave_number]]];
 			pointer = select(CIGAR_X, CIGAR_EQ, (read_char_cache == scaff[ref_index * interleave_number]));
+			#else
+			short score = 0;
+			if(direction[global_index] == 0) {
+				score = scoresFWD[trans[read_char_cache]][trans[scaff[ref_index * interleave_number]]];
+			} else {
+				score = scoresREV[trans[read_char_cache]][trans[scaff[ref_index * interleave_number]]];
+			}
+			diag_cell += score;
+			pointer = select(CIGAR_X, CIGAR_EQ, (read_char_cache == scaff[ref_index * interleave_number]));
+			#endif
 
 			short up_cell = local_matrix_line[(ref_index + 1) * threads_per_block] + gap_read;
 

--- a/lib/mason/opencl/opencl/oclSwScore.cl
+++ b/lib/mason/opencl/opencl/oclSwScore.cl
@@ -1,6 +1,6 @@
 #ifdef __CPU__
 
-#ifndef __BS__
+#ifndef __ALT_SCORING__
 __kernel void oclSW_Score(__global char const * scaff, __global char const * read, __global short * result, __global char * matrix) {
 #else
 __kernel void oclSW_Score(__global char const * scaff, __global char const * read, __global short * result, __global char * matrix, __global char const * direction) {
@@ -58,12 +58,12 @@ __kernel void oclSW_Score(__global char const * scaff, __global char const * rea
 			for (short ref_index = 0; ref_index < corridor_length - 1; ++ref_index) {
 				//init values
 				left_cell += gap_ref4;
-#ifndef __BS__
+#ifndef __ALT_SCORING__
 				float4 score = (float4)(scores[read_char_cache.s0][trans[scaff[ref_index]]], scores[read_char_cache.s1][trans[scaff[ref_index + 1 * ref_length]]], scores[read_char_cache.s2][trans[scaff[ref_index + 2 * ref_length]]], scores[read_char_cache.s3][trans[scaff[ref_index + 3 * ref_length]]]);
 				float4 diag_cell = local_matrix_line[ref_index] + score;
 				float4 pointerX = select(CIGAR_X4, CIGAR_EQ4, (score == match));
 #else
-				float4 score = select((float4)(scoresAG[read_char_cache.s0][trans[scaff[ref_index]]], scoresAG[read_char_cache.s1][trans[scaff[ref_index + 1 * ref_length]]], scoresAG[read_char_cache.s2][trans[scaff[ref_index + 2 * ref_length]]], scoresAG[read_char_cache.s3][trans[scaff[ref_index + 3 * ref_length]]]), (float4)(scoresTC[read_char_cache.s0][trans[scaff[ref_index]]], scoresTC[read_char_cache.s1][trans[scaff[ref_index + 1 * ref_length]]], scoresTC[read_char_cache.s2][trans[scaff[ref_index + 2 * ref_length]]], scoresTC[read_char_cache.s3][trans[scaff[ref_index + 3 * ref_length]]]), direction4 == 0);
+				float4 score = select((float4)(scoresREV[read_char_cache.s0][trans[scaff[ref_index]]], scoresREV[read_char_cache.s1][trans[scaff[ref_index + 1 * ref_length]]], scoresREV[read_char_cache.s2][trans[scaff[ref_index + 2 * ref_length]]], scoresREV[read_char_cache.s3][trans[scaff[ref_index + 3 * ref_length]]]), (float4)(scoresFWD[read_char_cache.s0][trans[scaff[ref_index]]], scoresFWD[read_char_cache.s1][trans[scaff[ref_index + 1 * ref_length]]], scoresFWD[read_char_cache.s2][trans[scaff[ref_index + 2 * ref_length]]], scoresFWD[read_char_cache.s3][trans[scaff[ref_index + 3 * ref_length]]]), direction4 == 0);
 
 				float4 diag_cell = local_matrix_line[ref_index] + score;
 				float4 pointerX = select(CIGAR_X4, CIGAR_EQ4, (read_char_cache == (int4)(trans[scaff[ref_index]], trans[scaff[ref_index + 1 * ref_length]], trans[scaff[ref_index + 2 * ref_length]], trans[scaff[ref_index + 3 * ref_length]])));
@@ -107,7 +107,7 @@ __kernel void oclSW_Score(__global char const * scaff, __global char const * rea
 }
 
 
-#ifndef __BS__
+#ifndef __ALT_SCORING__
 __kernel void oclSW(__global char const * scaff, __global char const * read, __global float * results) {
 #else
 __kernel void oclSW(__global char const * scaff, __global char const * read, __global float * results, __global char const * direction) {
@@ -137,10 +137,10 @@ __kernel void oclSW(__global char const * scaff, __global char const * read, __g
 				//Max can be set to left_cell because we are computing the score row-wise, so the actual max is the left_cell for the next cell
 				left_cell = max(null4, left_cell + gap_ref);
 				left_cell = max(matrix_lines[(ref_index + 1)] + gap_read, left_cell);
-#ifndef __BS__
+#ifndef __ALT_SCORING__
 				float4 scores4 = (float4)(scores[read_char_cache.s0][trans[scaff[ref_index]]], scores[read_char_cache.s1][trans[scaff[ref_index + 1 * ref_length]]], scores[read_char_cache.s2][trans[scaff[ref_index + 2 * ref_length]]], scores[read_char_cache.s3][trans[scaff[ref_index + 3 * ref_length]]]);
 #else
-				float4 scores4 = select((float4)(scoresAG[read_char_cache.s0][trans[scaff[ref_index]]], scoresAG[read_char_cache.s1][trans[scaff[ref_index + 1 * ref_length]]], scoresAG[read_char_cache.s2][trans[scaff[ref_index + 2 * ref_length]]], scoresAG[read_char_cache.s3][trans[scaff[ref_index + 3 * ref_length]]]), (float4)(scoresTC[read_char_cache.s0][trans[scaff[ref_index]]], scoresTC[read_char_cache.s1][trans[scaff[ref_index + 1 * ref_length]]], scoresTC[read_char_cache.s2][trans[scaff[ref_index + 2 * ref_length]]], scoresTC[read_char_cache.s3][trans[scaff[ref_index + 3 * ref_length]]]), direction4 == 0);
+				float4 scores4 = select((float4)(scoresREV[read_char_cache.s0][trans[scaff[ref_index]]], scoresREV[read_char_cache.s1][trans[scaff[ref_index + 1 * ref_length]]], scoresREV[read_char_cache.s2][trans[scaff[ref_index + 2 * ref_length]]], scoresREV[read_char_cache.s3][trans[scaff[ref_index + 3 * ref_length]]]), (float4)(scoresFWD[read_char_cache.s0][trans[scaff[ref_index]]], scoresFWD[read_char_cache.s1][trans[scaff[ref_index + 1 * ref_length]]], scoresFWD[read_char_cache.s2][trans[scaff[ref_index + 2 * ref_length]]], scoresFWD[read_char_cache.s3][trans[scaff[ref_index + 3 * ref_length]]]), direction4 == 0);
 #endif
 				left_cell = max(matrix_lines[ref_index] + scores4, left_cell);
 				curr_max = max(curr_max, left_cell);
@@ -215,7 +215,7 @@ void interleaveSeq(__global char const * _src, __global char * dest) {
 
 #ifdef __GPU__
 
-#ifndef __BS__
+#ifndef __ALT_SCORING__
 __kernel void oclSW_Score(__global char const * scaff, __global char const * read, __global short * result, __global char * matrix) {
 #else
 __kernel void oclSW_Score(__global char const * scaff, __global char const * read, __global short * result, __global char * matrix, __global char const * direction) {
@@ -270,15 +270,15 @@ __kernel void oclSW_Score(__global char const * scaff, __global char const * rea
 			//			printf("%c == %c\n", read_char_cache, scaff[ref_index * interleave_number]);
 			int pointer = CIGAR_X;
 
-#ifndef __BS__
+#ifndef __ALT_SCORING__
 			diag_cell += scores[trans[read_char_cache]][trans[scaff[ref_index * interleave_number]]];
 			pointer = select(CIGAR_X, CIGAR_EQ, (read_char_cache == scaff[ref_index * interleave_number]));
 #else
 			short score = 0;
 			if(direction[global_index] == 0) {
-				score = scoresTC[trans[read_char_cache]][trans[scaff[ref_index * interleave_number]]];
+				score = scoresFWD[trans[read_char_cache]][trans[scaff[ref_index * interleave_number]]];
 			} else {
-				score = scoresAG[trans[read_char_cache]][trans[scaff[ref_index * interleave_number]]];
+				score = scoresREV[trans[read_char_cache]][trans[scaff[ref_index * interleave_number]]];
 			}
 			diag_cell += score;
 			pointer = select(CIGAR_X, CIGAR_EQ, (read_char_cache == scaff[ref_index * interleave_number]));
@@ -328,7 +328,7 @@ __kernel void oclSW_Score(__global char const * scaff, __global char const * rea
 	}
 }
 
-#ifndef __BS__
+#ifndef __ALT_SCORING__
 __kernel void oclSW(__global char const * scaff, __global char const * read, __global float * results) {
 #else
 __kernel void oclSW(__global char const * scaff, __global char const * read, __global float * results, __global char const * direction) {
@@ -354,13 +354,13 @@ __kernel void oclSW(__global char const * scaff, __global char const * read, __g
 		for (int ref_index = 0; ref_index < (corridor_length - 1); ++ref_index) {
 
 			short diag_cell = matrix_lines[ref_index * threads_per_block];
-#ifndef __BS__
+#ifndef __ALT_SCORING__
 			diag_cell += scores[trans[read_char_cache]][trans[scaff[ref_index * interleave_number]]];
 #else
 			if(direction[global_index] == 0) {
-				diag_cell += scoresTC[trans[read_char_cache]][trans[scaff[ref_index * interleave_number]]];
+				diag_cell += scoresFWD[trans[read_char_cache]][trans[scaff[ref_index * interleave_number]]];
 			} else {
-				diag_cell += scoresAG[trans[read_char_cache]][trans[scaff[ref_index * interleave_number]]];
+				diag_cell += scoresREV[trans[read_char_cache]][trans[scaff[ref_index * interleave_number]]];
 			}
 #endif
 			//Max can be set to left_cell because we are computing the score row-wise, so the actual max is the left_cell for the next cell

--- a/src/AlignmentBuffer.cpp
+++ b/src/AlignmentBuffer.cpp
@@ -79,6 +79,7 @@ void AlignmentBuffer::DoRun() {
 			//Initialize
 			if (cur_read->Scores[scoreID].Location.isReverse()) {
 				qryBuffer[i] = cur_read->RevSeq;
+				qalBuffer[i] = cur_read->qlty;
 
 				if (cur_read->Paired != 0) {
 					m_DirBuffer[i] = !(cur_read->ReadId & 1);
@@ -88,6 +89,7 @@ void AlignmentBuffer::DoRun() {
 
 			} else {
 				qryBuffer[i] = cur_read->Seq;
+				qalBuffer[i] = cur_read->qlty;
 				if (cur_read->Paired != 0) {
 					m_DirBuffer[i] = cur_read->ReadId & 1; //0 if first pair
 				} else {
@@ -109,7 +111,7 @@ void AlignmentBuffer::DoRun() {
 		}
 
 		//start alignment
-		int aligned = aligner->BatchAlign(alignmode | (std::max(outputformat, 1) << 8), count, refBuffer, qryBuffer, alignBuffer,
+		int aligned = aligner->BatchAlign(alignmode | (std::max(outputformat, 1) << 8), count, refBuffer, qryBuffer, qalBuffer, alignBuffer,
 				(m_EnableBS || slamSeq) ? m_DirBuffer : 0);
 
 		Log.Debug(32, "INFO\tALGN\t%d alignments computed (out of %d)", aligned, count);

--- a/src/AlignmentBuffer.cpp
+++ b/src/AlignmentBuffer.cpp
@@ -110,7 +110,7 @@ void AlignmentBuffer::DoRun() {
 
 		//start alignment
 		int aligned = aligner->BatchAlign(alignmode | (std::max(outputformat, 1) << 8), count, refBuffer, qryBuffer, alignBuffer,
-				(m_EnableBS) ? m_DirBuffer : 0);
+				(m_EnableBS || slamSeq) ? m_DirBuffer : 0);
 
 		Log.Debug(32, "INFO\tALGN\t%d alignments computed (out of %d)", aligned, count);
 

--- a/src/AlignmentBuffer.h
+++ b/src/AlignmentBuffer.h
@@ -21,7 +21,6 @@ private:
 
 	int const outputformat;
 	int const alignmode;
-	bool m_EnableBS;
 	int const batchSize;
 	int const corridor;
 	uloc const refMaxLen;
@@ -31,6 +30,7 @@ private:
 	int nReads;
 	char const * * qryBuffer;
 	char const * * refBuffer;
+	//char const * * qalBuffer;
 	char * m_DirBuffer;
 	int dbLen;
 	Align * alignBuffer;
@@ -50,6 +50,8 @@ private:
 	IAlignment * aligner;
 
 	bool const argos;
+	bool const m_EnableBS;
+	int const slamSeq;
 
 	void debugAlgnFinished(MappedRead * read);
 
@@ -64,15 +66,12 @@ public:
 					corridor(Config.GetInt("corridor")),
 					refMaxLen((Config.GetInt("qry_max_len") + corridor) | 1 + 1),
 					min_mq(Config.GetInt(MIN_MQ)),
-					aligner(mAligner), argos(Config.Exists(ARGOS)) {
+					aligner(mAligner), argos(Config.Exists(ARGOS)), m_EnableBS(Config.GetInt("bs_mapping", 0, 1) == 1), slamSeq(Config.GetInt(SLAM_SEQ)) {
 						pairInsertSum = 0;
 						pairInsertCount = 0;
 						brokenPairs = 0;
 						m_Writer = 0;
 						nReads = 0;
-
-						m_EnableBS = false;
-						m_EnableBS = (Config.GetInt("bs_mapping", 0, 1) == 1);
 
 						int const outputformat = NGM.GetOutputFormat();
 
@@ -104,6 +103,7 @@ public:
 
 						qryBuffer = new char const *[batchSize];
 						refBuffer = new char const *[batchSize];
+						//qalBuffer = new char const *[batchSize];
 
 						for (int i = 0; i < batchSize; ++i) {
 							refBuffer[i] = new char[refMaxLen];
@@ -134,6 +134,7 @@ public:
 
 						qryBuffer = new char const *[batchSize];
 						refBuffer = new char const *[batchSize];
+						//qalBuffer = new char const *[batchSize];
 
 						for (int i = 0; i < batchSize; ++i) {
 							refBuffer[i] = new char[refMaxLen];
@@ -167,6 +168,7 @@ public:
 						}
 						delete[] qryBuffer;
 						delete[] refBuffer;
+						//delete[] qalBuffer;
 						delete[] alignBuffer;
 
 						delete[] reads;

--- a/src/AlignmentBuffer.h
+++ b/src/AlignmentBuffer.h
@@ -30,7 +30,7 @@ private:
 	int nReads;
 	char const * * qryBuffer;
 	char const * * refBuffer;
-	//char const * * qalBuffer;
+	char const * * qalBuffer;
 	char * m_DirBuffer;
 	int dbLen;
 	Align * alignBuffer;
@@ -103,7 +103,7 @@ public:
 
 						qryBuffer = new char const *[batchSize];
 						refBuffer = new char const *[batchSize];
-						//qalBuffer = new char const *[batchSize];
+						qalBuffer = new char const *[batchSize];
 
 						for (int i = 0; i < batchSize; ++i) {
 							refBuffer[i] = new char[refMaxLen];
@@ -134,7 +134,7 @@ public:
 
 						qryBuffer = new char const *[batchSize];
 						refBuffer = new char const *[batchSize];
-						//qalBuffer = new char const *[batchSize];
+						qalBuffer = new char const *[batchSize];
 
 						for (int i = 0; i < batchSize; ++i) {
 							refBuffer[i] = new char[refMaxLen];
@@ -168,7 +168,7 @@ public:
 						}
 						delete[] qryBuffer;
 						delete[] refBuffer;
-						//delete[] qalBuffer;
+						delete[] qalBuffer;
 						delete[] alignBuffer;
 
 						delete[] reads;

--- a/src/CS.cpp
+++ b/src/CS.cpp
@@ -64,6 +64,8 @@ void CS::PrefixMutateSearch(ulong prefix, uloc pos, ulong mutateFrom,
 			++mutationLocs;
 	}
 
+	Log.Verbose("Qry Seq %i - Prefix 0x%x -> %d k-mers", cs->m_CurrentSeq, prefix, mutationLocs + 1);
+
 	if (slamSeq) {
 		CS * cs = (CS*) data;
 		cs->m_CurrentMutLocs = 1;
@@ -149,6 +151,7 @@ void CS::PrefixSearch(ulong prefix, uloc pos, ulong mutateFrom, ulong mutateTo,
 				uloc loc = cur->getRealLocation(cur->ref[i]);
 				cs->AddLocationStd(GetBin(loc - correction), cur->reverse,
 						weight);
+				Log.Verbose("Qry Seq %i - Prefix 0x%x pos %llu weight %f", cs->m_CurrentSeq, prefix, GetBin(loc - correction), weight);
 			}
 
 			cur++;

--- a/src/CS.h
+++ b/src/CS.h
@@ -44,12 +44,15 @@ protected:
 	std::vector<MappedRead*> m_CurrentBatch;
 	int m_CurrentSeq;
 	int m_CurrentReadLength;
+	//SlamSeq. Number of Ts in k-mer
+	int m_CurrentMutLocs;
 	int m_ProcessedReads;
 	int m_WrittenReads;
 	int m_DiscardedReads;
 	//	volatile int m_Candidates;
 	int m_Mode;
 	bool m_EnableBS;
+	int m_EnableSlamSeq;
 	int m_Overflows;
 	//float weightSum;
 	const IRefProvider* m_RefProvider;
@@ -66,6 +69,7 @@ protected:
 	static void PrefixSearch(ulong prefix, uloc pos, ulong mutateFrom, ulong mutateTo, void* data);
 
 	static void PrefixMutateSearchEx(ulong prefix, uloc pos, ulong mutateFrom, ulong mutateTo, void* data, int mpos = 0);
+	static void PrefixMutateSearchSlamSeq(ulong prefix, uloc pos, ulong mutateFrom,	ulong mutateTo, void* data, int mpos = 0);
 	virtual int CollectResultsStd(MappedRead* read);
 	int CollectResultsFallback(MappedRead* read);
 	void FilterScore(LocationScore* score);

--- a/src/MappedRead.cpp
+++ b/src/MappedRead.cpp
@@ -94,6 +94,9 @@ MappedRead::~MappedRead() {
 			if (Alignments[i].pBuffer2 != 0)
 				delete[] Alignments[i].pBuffer2;
 			Alignments[i].pBuffer2 = 0;
+			if(Alignments[i].ExtendedData != 0)
+				delete[] (int *)Alignments[i].ExtendedData;
+			Alignments[i].ExtendedData = 0;
 		}
 		delete[] Alignments;
 		Alignments = 0;

--- a/src/ScoreBuffer.cpp
+++ b/src/ScoreBuffer.cpp
@@ -124,7 +124,7 @@ void ScoreBuffer::DoRun() {
 		//Compute scores
 		//TODO: move to NGMStats
 		ScoreBuffer::scoreCount += iScores;
-		int res = aligner->BatchScore(m_AlignMode, iScores, m_RefBuffer, m_QryBuffer, m_ScoreBuffer, (m_EnableBS || slamSeq) ? m_DirBuffer : 0);
+		int res = aligner->BatchScore(m_AlignMode, iScores, m_RefBuffer, m_QryBuffer, 0, m_ScoreBuffer, (m_EnableBS || slamSeq) ? m_DirBuffer : 0);
 
 		Log.Debug(16, "INFO\tSCORES\t%d scores computed (out of %d)", res, iScores);
 

--- a/src/ScoreBuffer.cpp
+++ b/src/ScoreBuffer.cpp
@@ -34,7 +34,7 @@ bool sortLocationScore(LocationScore a, LocationScore b) {
 int ScoreBuffer::computeMQ(float bestScore, float secondBestScore) {
 	int mq = 0;
 	if (bestScore > 0 && secondBestScore >= 0) {
-		ceil(MAX_MQ * (bestScore - secondBestScore) / bestScore);
+		mq = ceil(MAX_MQ * (bestScore - secondBestScore) / bestScore);
 	}
 	return mq;
 }

--- a/src/ScoreBuffer.cpp
+++ b/src/ScoreBuffer.cpp
@@ -124,7 +124,7 @@ void ScoreBuffer::DoRun() {
 		//Compute scores
 		//TODO: move to NGMStats
 		ScoreBuffer::scoreCount += iScores;
-		int res = aligner->BatchScore(m_AlignMode, iScores, m_RefBuffer, m_QryBuffer, m_ScoreBuffer, (m_EnableBS) ? m_DirBuffer : 0);
+		int res = aligner->BatchScore(m_AlignMode, iScores, m_RefBuffer, m_QryBuffer, m_ScoreBuffer, (m_EnableBS || slamSeq) ? m_DirBuffer : 0);
 
 		Log.Debug(16, "INFO\tSCORES\t%d scores computed (out of %d)", res, iScores);
 
@@ -530,4 +530,3 @@ void ScoreBuffer::flush() {
 	iScores = 0;
 	out->flush();
 }
-

--- a/src/ScoreBuffer.h
+++ b/src/ScoreBuffer.h
@@ -67,7 +67,8 @@ private:
 
 	int corridor;
 	char * m_DirBuffer;
-	bool m_EnableBS;
+	bool const m_EnableBS;
+	int const slamSeq;
 
 	Score * scores;
 	int iScores;
@@ -88,7 +89,8 @@ public:
 	ScoreBuffer(IAlignment * mAligner, AlignmentBuffer * mOut) :
 			m_AlignMode(Config.GetInt(MODE, 0, 1)), pairDistCount(1), pairDistSum(0), brokenPairs(0), pairScoreCutoff(Config.GetFloat("pair_score_cutoff")), topN(Config.GetInt("topn")), strata(
 					Config.GetInt("strata")), isPaired(Config.GetInt("paired") != 0), fastPairing(Config.GetInt("fast_pairing") == 1), aligner(
-					mAligner), out(mOut), swBatchSize(aligner->GetScoreBatchSize()), argos(Config.Exists(ARGOS)), argosMinScore(Config.GetFloat(ARGOS_MINSCORE)) {
+					mAligner), out(mOut), swBatchSize(aligner->GetScoreBatchSize()), m_EnableBS(Config.GetInt("bs_mapping", 0, 1) == 1), slamSeq(
+					Config.GetInt(SLAM_SEQ)), argos(Config.Exists(ARGOS)), argosMinScore(Config.GetFloat(ARGOS_MINSCORE)) {
 
 		m_QryBuffer = 0;
 		m_RefBuffer = 0;

--- a/src/ScoreBuffer.h
+++ b/src/ScoreBuffer.h
@@ -104,9 +104,9 @@ public:
 
 		m_DirBuffer = new char[swBatchSize];
 
-		m_EnableBS = false;
+		//m_EnableBS = false;
 		//	if (Config.Exists("bs_mapping"))
-		m_EnableBS = (Config.GetInt("bs_mapping", 0, 1) == 1);
+		//m_EnableBS = (Config.GetInt("bs_mapping", 0, 1) == 1);
 
 		qryMaxLen = Config.GetInt("qry_max_len");
 		refMaxLen = ((qryMaxLen + Config.GetInt("corridor")) | 1) + 1;

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,9 +1,8 @@
 #ifndef VERSION_H
 #define VERSION_H
- 
+
 #define VERSION_MAJOR "0"
 #define VERSION_MINOR "4"
-#define VERSION_BUILD "13"
+#define VERSION_BUILD "13-slambr"
 
 #endif // VERSION_H
-

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -449,6 +449,10 @@ _Config::_Config(int argc, char * argv[], bool praseArgs) {
 				Log.Error("'--bs-mapping' and '--affine' can't be used at the same time!");
 				Fatal();
 			}
+			if(Exists(SLAM_SEQ)) {
+				Log.Error("'--bs-mapping' and '--slam-seq' can't be used at the same time!");
+				Fatal();
+			}
 			if(Exists(ENDTOEND)) {
 				Log.Error("'--bs-mapping' and '--e/--end-to-end' can't be used at the same time!");
 				Fatal();
@@ -489,6 +493,8 @@ _Config::_Config(int argc, char * argv[], bool praseArgs) {
 
 		//BS-mapping
 		Default("bs_cutoff", 6);
+
+		Default(SLAM_SEQ, 0);
 
 		//Others
 		Default("no_progress", 0);
@@ -667,4 +673,3 @@ gpu = 1 { 0 }\n\
 mason_path = 	/software/ngm/ngm/mason/	\n\
 \n\
 \n";
-

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -443,6 +443,8 @@ _Config::_Config(int argc, char * argv[], bool praseArgs) {
 				Default(GAP_REF_PENALTY, 20);
 				Default(GAP_EXTEND_PENALTY, 5);
 			}
+			Default(MATCH_BONUS_TT, 10);
+			Default(MATCH_BONUS_TC, 2);
 		} else {
 			Log.Message("Using bs-mapping scoring scheme");
 			if(GetInt("affine")) {
@@ -463,9 +465,9 @@ _Config::_Config(int argc, char * argv[], bool praseArgs) {
 			Default(GAP_READ_PENALTY, 10);
 			Default(GAP_REF_PENALTY, 10);
 			Default(GAP_EXTEND_PENALTY, 2);
+			Default(MATCH_BONUS_TT, 4);
+			Default(MATCH_BONUS_TC, 4);
 		}
-		Default(MATCH_BONUS_TT, 4);
-		Default(MATCH_BONUS_TC, 4);
 
 		//Silent
 		Default("dualstrand", 1);
@@ -507,7 +509,9 @@ _Config::_Config(int argc, char * argv[], bool praseArgs) {
 
 		Default(MAX_READ_LENGTH, 0);
 
-		Default(BIN_SIZE, 3);
+		Default(BIN_SIZE, 2);
+
+		Default(TRIM5, 0);
 
 		if(Exists(ARGOS)) {
 			Default("sensitivity", 0.0f);
@@ -524,7 +528,7 @@ _Config::_Config(int argc, char * argv[], bool praseArgs) {
 #endif
 
 #ifdef DEBUGLOG
-//	Default("log_lvl", "16383");
+	//Default("log_lvl", "16383");
 	Default("log_lvl", "255");
 	//Default(LOG_LVL, "0");
 #endif

--- a/src/config/Options.h
+++ b/src/config/Options.h
@@ -93,6 +93,7 @@ static const struct option long_options[] =
 		{ "max-read-length",            required_argument, 0, 0 },
 		{ "force-rlength-check",        no_argument,       0, 0 },
 		{ "bin-size",                   required_argument,       0, 0 },
+		{ "slam-seq",                   required_argument,       0, 0 },
 		{ "very-fast",                  no_argument,       0, 0 },
 		{ "fast",                       no_argument,       0, 0 },
 		{ "sensitive",                  no_argument,       0, 0 },

--- a/src/config/Options.h
+++ b/src/config/Options.h
@@ -10,7 +10,7 @@
 
 #include <getopt.h>
 
-static char const * getopt_short = "c:o:q:r:t:gs:m:f:k:pleI:X:i:n:R:C:b1:2:d:Q:";
+static char const * getopt_short = "c:o:q:r:t:gs:m:f:k:pleI:X:i:n:R:C:b1:2:d:Q:5:";
 
 //Here '-' has to be used and not '_'. When querying the Config the '-' has to be replaced by '_'.
 //When passing parameters trough the config file '-' and '_' can both be used.
@@ -98,7 +98,8 @@ static const struct option long_options[] =
 		{ "fast",                       no_argument,       0, 0 },
 		{ "sensitive",                  no_argument,       0, 0 },
 		{ "very-sensitive",             no_argument,       0, 0 },
-		{ "max-kfreq",             		required_argument,       0, 0 },
+		{ "max-kfreq",                  required_argument,       0, 0 },
+		{ TRIM5,                        required_argument,       0, '5' },
 	0 };
 
 #endif /* OPTIONS_H_ */

--- a/src/seqan/EndToEndAffine.cpp
+++ b/src/seqan/EndToEndAffine.cpp
@@ -7,7 +7,7 @@
 
 #include "EndToEndAffine.h"
 
-int EndToEndAffine::BatchScore(int const mode, int const batchSize, char const * const * const refSeqList, char const * const * const qrySeqList, float * const results, void * extData) {
+int EndToEndAffine::BatchScore(int const mode, int const batchSize, char const * const * const refSeqList, char const * const * const qrySeqList, char const * const * const qalSeqList, float * const results, void * extData) {
 	for(int i = 0; i < batchSize; ++i) {
 		switch(m_AlignMode) {
 			case 0:
@@ -27,7 +27,7 @@ int EndToEndAffine::BatchScore(int const mode, int const batchSize, char const *
 	return batchSize;
 }
 
-int EndToEndAffine::BatchAlign(int const mode, int const batchSize, char const * const * const refSeqList, char const * const * const qrySeqList, Align * const results, void * extData) {
+int EndToEndAffine::BatchAlign(int const mode, int const batchSize, char const * const * const refSeqList, char const * const * const qrySeqList, char const * const * const qalSeqList, Align * const results, void * extData) {
 	for(int i = 0; i < batchSize; ++i) {
 
 		TGaps gapsText;

--- a/src/seqan/EndToEndAffine.h
+++ b/src/seqan/EndToEndAffine.h
@@ -48,9 +48,9 @@ public:
 		return 1024;
 	}
 
-	virtual int BatchScore(int const mode, int const batchSize, char const * const * const refSeqList, char const * const * const qrySeqList, float * const results, void * extData);
+	virtual int BatchScore(int const mode, int const batchSize, char const * const * const refSeqList, char const * const * const qrySeqList, char const * const * const qalSeqList, float * const results, void * extData);
 
-	virtual int BatchAlign(int const mode, int const batchSize, char const * const * const refSeqList, char const * const * const qrySeqList, Align * const results, void * extData);
+	virtual int BatchAlign(int const mode, int const batchSize, char const * const * const refSeqList, char const * const * const qrySeqList, char const * const * const qalSeqList, Align * const results, void * extData);
 
 	void convertToCIGAR(TGaps gapsText, TGaps gapsPattern, Align & result, int const readLen);
 

--- a/src/writer/SAMWriter.cpp
+++ b/src/writer/SAMWriter.cpp
@@ -179,6 +179,29 @@ void SAMWriter::DoWriteReadGeneric(MappedRead const * const read, int const scor
 	Print("XR:i:%d\t", read->length - read->Alignments[scoreID].QStart - read->Alignments[scoreID].QEnd);
 	Print("MD:Z:%s", read->Alignments[scoreID].pBuffer2);
 
+	//Add TC and RA tag for TC conversions and feedback of all mutations
+	if(read->Alignments[scoreID].ExtendedData != 0) {
+		int * rates = (int *) read->Alignments[scoreID].ExtendedData;
+		char str[5 * 5 * 4];
+		int index = 0;
+		for (int i = 0; i < 5; ++i) {
+			for (int j = 0; j < 5; ++j) {
+				int number = rates[i * 5 + j];
+				//Log.Message("%c -> %c: %d", back[i], back[j], number);
+				index += sprintf(str + index, "%d,", number);
+			}
+		}
+
+		if(read->Scores[scoreID].Location.isReverse()) {
+			Print("\tTC:i:%d", rates[5 * 0 + 2]);
+		} else {
+			Print("\tTC:i:%d", rates[5 * 3 + 1]);
+		}
+
+		Print("\tRA:Z:%.*s", index - 1, str);
+
+	}
+
 	Print("\n");
 
 }


### PR DESCRIPTION
This PR adds in T>C conversion mapping and the required scoring scheme.
In addition I've also added the 5p-trimming capability from previous code and also squashed some minor bugs that I noticed (see line comments).

I have also considered adding 3p trimming in, too, to simplify my workflow, but maybe I'll get round to that later on.