### PR TITLE
Initial implementation of broken paired end input

### DIFF
--- a/src/MappedRead.h
+++ b/src/MappedRead.h
@@ -20,7 +20,7 @@ struct MappedRead {
 private:
 
 public:
-	int const ReadId;
+	int ReadId;
 
 	//Calculated is initialized with -1. This shows that the read has not passed the candidate search
 	//When the read is submitted to the score computation calculated is set to 0. Each time a score

--- a/src/ReadProvider.h
+++ b/src/ReadProvider.h
@@ -28,12 +28,15 @@ private:
 
 	IParser * parser1;
 	IParser * parser2;
+	MappedRead * _spare_read;
 
 	char const peDelimiter;
 
 	bool const isPaired;
 
 	bool const skipMateCheck;
+
+    bool const acceptBrokenPaired;
 
 	virtual MappedRead * NextRead(IParser * parser, int const id);
 	MappedRead * GenerateSingleRead(int const readid);


### PR DESCRIPTION
See #23.

This is an **initial** implementation/proof of concept. It seems to work for me but probably has bugs. 

Known issues:

- [ ] clean up `_spare_read`
- [ ] add CLI flag for `acceptBrokenPaired`
- [ ] fix indentation