### PR TITLE
Fix missing defines using latest Intel compiler

### DIFF
--- a/lib/mason/opencl/OclHost.h
+++ b/lib/mason/opencl/OclHost.h
@@ -14,6 +14,7 @@
 #include <CL/opencl.h>
 #//endif
 
+#include <cstdlib>
 #include <string>
 
 #include "ILog.h"


### PR DESCRIPTION
The attached change was required to get NGM to build on our cluster, which uses ICC 17.

Cheers,
K